### PR TITLE
Not nullable mandatory default value should apply to SQlite only

### DIFF
--- a/SchemaBuilder/lib/db/sql/schema.php
+++ b/SchemaBuilder/lib/db/sql/schema.php
@@ -480,7 +480,7 @@ class Schema {
             'ibm' => 'WITH DEFAULT',
         );
         // not nullable fields should have a default value [SQlite]
-        if ($default === false && $nullable === false) {
+        if ($default === false && $nullable === false && preg_match('/sqlite2?/', $this->db->driver())) {
             trigger_error(sprintf(self::TEXT_NotNullFieldNeedsDefault, $name));
             return false;
         }


### PR DESCRIPTION
..so that the NOT NULL constraint works in other engines.
