### PR TITLE
Make standardising 'id' -> '_id' in cast() optional

### DIFF
--- a/Cortex/lib/db/cortex.php
+++ b/Cortex/lib/db/cortex.php
@@ -40,6 +40,8 @@ class Cortex extends Cursor {
         $collectionID,  // collection set identifier
         $relFilter;     // filter for loading related models
 
+	protected $standardiseID = true;	//return standard '_id' for SQL, not 'id'
+		
     /** @var Cursor */
     protected $mapper;
 
@@ -1008,7 +1010,7 @@ class Cortex extends Cursor {
                 }
                 if ($this->dbsType == 'mongo' && $key == '_id')
                     $val = (string) $val;
-                if ($this->dbsType == 'sql' && $key == 'id') {
+                if ($this->dbsType == 'sql' && $key == 'id' && $this->standardiseID) {
                     $fields['_id'] = $val;
                     unset($fields[$key]);
                 }


### PR DESCRIPTION
Can we make standardising id field optional (but enabled by default maybe?)

Forcing it has the end effect the key for the id field in the returned array different from the actual field name in the database. This seems like a recipe for confusion. Especially when considering actually renaming the id field to _id in sql can cause even more problems.
