### PR TITLE
Fail helpfully if no relations found for MM-Bi

### DIFF
--- a/Cortex/lib/db/cortex.php
+++ b/Cortex/lib/db/cortex.php
@@ -792,6 +792,9 @@ class Cortex extends Cursor {
                                     $fRel = $this->getRelInstance($fromConf[0]);
                                     $crit = array($id.' IN ?', $pivotKeys);
                                     $relSet = $fRel->find($this->mergeWithRelFilter($key, $crit));
+									if($relSet === false){
+                                        trigger_error(sprintf(self::E_REL_CONF_INC, $key));
+                                    }
                                     $cx->setRelSet($key, $relSet->getBy($id));
                                     unset($fRel);
                                 }


### PR DESCRIPTION
When doing MM bidirectional, if NO foreign relations were found, it would fail with:
"Fatal error: Call to a member function getBy() on a non-object"

Only an issue if 0 relations are found.
